### PR TITLE
fix: close modal and show toast when deleting tag

### DIFF
--- a/internal/i18n/translations/en.json
+++ b/internal/i18n/translations/en.json
@@ -53,6 +53,7 @@
   "toast.todo_created": "Todo created",
   "toast.todo_updated": "Todo updated",
   "toast.todo_deleted": "Todo deleted",
+  "toast.tag_deleted": "Tag deleted",
   "toast.status_changed": "Todo status changed to {{.Status}}",
   "toast.archived": "Todo archived",
   "toast.unarchived": "Todo unarchived",

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -92,7 +92,7 @@ func CompletedTodayFilter() Filter {
 		now := time.Now()
 		today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 
-		return "status = ? AND updated_at >= ?",
+		return "status = ? AND t.updated_at >= ?",
 			[]interface{}{models.Done, today}
 	}
 }

--- a/internal/ui/confirm-delete.go
+++ b/internal/ui/confirm-delete.go
@@ -90,8 +90,10 @@ func (m *ConfirmDeleteModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.deleteTag {
 				// If deleting a tag, call the deleteTagCmd
 				return m, m.deleteTagCmd()
+			} else {
+				// If deleting a todo, call the deleteTodoCmd
+				return m, m.deleteTodoCmd()
 			}
-			return m, m.deleteTodoCmd()
 		}
 	case tea.WindowSizeMsg:
 		m.width = msg.Width

--- a/internal/ui/main.go
+++ b/internal/ui/main.go
@@ -142,6 +142,11 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmds = append(cmds, m.loadTodosCmd())
 		cmds = append(cmds, ShowDefaultToast(m.translator.T("toast.todo_deleted"), SuccessToast))
 
+	case tagDeletedMsg:
+		m.tuiService.SwitchToListView()
+		cmds = append(cmds, m.loadTagsCmd())
+		cmds = append(cmds, ShowDefaultToast(m.translator.T("toast.tag_deleted"), SuccessToast))
+
 	case todoStatusChangedMsg:
 		cmds = append(cmds, m.loadTodosCmd())
 		cmds = append(cmds, ShowDefaultToast(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a toast notification to confirm successful tag deletion.
  - Improved user interface feedback and behavior when deleting tags, including automatic tag list refresh.

- **Bug Fixes**
  - Clarified the control flow when deleting tags or todos to ensure correct actions are taken.

- **Chores**
  - Updated English translations to include a message for tag deletion events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->